### PR TITLE
Add support for azurerm 2.x and azurecaf providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## v2.0 (March 2020)
+
+FEATURES: 
+* **new feature:**  Add support for azurerm 2.x and azurecaf providers ([#3](https://github.com/aztfmod/terraform-azurerm-caf-keyvault/issues/3))
+
+
+IMPROVEMENTS:
+
+BUGS:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitter](https://badges.gitter.im/aztfmod/community.svg)](https://gitter.im/aztfmod/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
 # Deploys an Azure Key Vault
 
 Creates an Azure Key Vault.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ module "azurekevault" {
 }
 ```
 
+## Inputs
+
+| Name | Type | Default | Description |
+| -- | -- | -- | -- |
+| resource_group_name | string | None | (Required) Name of the resource group where to create the resource. Changing this forces a new resource to be created. |
+| location | string | None | (Required) Specifies the Azure location to deploy the resource. Changing this forces a new resource to be created.  |
+| tags | map | None | (Required) Map of tags for the deployment.  |
+| log_analytics_workspace | string | None | (Required) Log Analytics Workspace. |
+| diagnostics_map | map | None | (Required) Map with the diagnostics repository information.  |
+| diagnostics_settings | object | None | (Required) Map with the diagnostics settings. See the required structure in the following example or in the diagnostics module documentation. |
+| akv_config | object | None | (Required) Key Vault Configuration Object as described in the Parameters section. |
+| convention | string | None | (Required) Naming convention to be used (check at the naming convention module for possible values).  |
+| prefix | string | None | (Optional) Prefix to be used. |
+| postfix | string | None | (Optional) Postfix to be used. |
+| max_length | string | None | (Optional) maximum length to the name of the resource. |
+
+
 ## Parameters
 
 ### akv_config
@@ -65,57 +82,6 @@ akv_config = {
 }
 ```
 
-### location
-
-(Required) Location of the resource to be created.
-
-```hcl
-variable "location" {
-  description = "(Required) Location of the AKV to be created"
-}
-```
-
-Sample:
-
-```hcl
-location = "southeastasia"
-```
-
-### resource_group_name
-
-(Required) Resource group of the resource to be created.
-
-```hcl
-variable "resource_group_name" {
-  description = "(Required) Resource group of the public IP to be created"
-}
-```
-
-Sample:
-
-```hcl
-resource_group_name = "myrg"
-```
-
-### tags
-
-(Required) Map of tags for the deployment.
-
-```hcl
-variable "tags" {
-  description = "(Required) map of tags for the deployment"
-}
-```
-
-Example
-
-```hcl
-tags = {
-    environment     = "DEV"
-    owner           = "Arnaud"
-    deploymentType  = "Terraform"
-  }
-```
 
 ## log_analytics_workspace
 
@@ -179,17 +145,6 @@ diagnostics_settings = {
 }
 ```
 
-## convention
-(Required) Naming convention to be used.
-```hcl
-variable "convention" {
-  description = "(Required) Naming convention used"
-}
-```
-Example
-```hcl
-convention = "cafclassic"
-```
 
 ## Output
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ module "azurekevault" {
 
     prefix                            = var.prefix
     location                          = var.location
-    rg                                = var.rg
+    resource_group_name               = var.resource_group_name
     akv_config                        = var.akv_config
     tags                              = var.tags
     diagnostics_settings              = var.ipdiags
@@ -81,12 +81,12 @@ Sample:
 location = "southeastasia"
 ```
 
-### rg
+### resource_group_name
 
 (Required) Resource group of the resource to be created.
 
 ```hcl
-variable "rg" {
+variable "resource_group_name" {
   description = "(Required) Resource group of the public IP to be created"
 }
 ```
@@ -94,7 +94,7 @@ variable "rg" {
 Sample:
 
 ```hcl
-rg = "myrg"
+resource_group_name = "myrg"
 ```
 
 ### tags

--- a/examples/akv/akv.tf
+++ b/examples/akv/akv.tf
@@ -11,7 +11,7 @@ resource "azurerm_resource_group" "rg_test" {
 
 module "la_test" {
   source  = "aztfmod/caf-log-analytics/azurerm"
-  version = "1.0.0"
+  version = "2.0.0"
   
     convention          = local.convention
     location            = local.location
@@ -24,7 +24,7 @@ module "la_test" {
 
 module "diags_test" {
   source  = "aztfmod/caf-diagnostics-logging/azurerm"
-  version = "1.0.0"
+  version = "2.0.0"
 
   resource_group_name   = azurerm_resource_group.rg_test.name
   prefix                = local.prefix

--- a/examples/akv/akv.tf
+++ b/examples/akv/akv.tf
@@ -1,42 +1,45 @@
-module "rg_test" {
-  source  = "aztfmod/caf-resource-group/azurerm"
-  version = "0.1.1"
-  
-    prefix          = local.prefix
-    resource_groups = local.resource_groups
-    tags            = local.tags
+provider "azurerm" {
+   features {}
 }
+
+resource "azurerm_resource_group" "rg_test" {
+  name     = local.resource_groups.test.name
+  location = local.resource_groups.test.location
+  tags     = local.tags
+}
+
 
 module "la_test" {
   source  = "aztfmod/caf-log-analytics/azurerm"
-  version = "0.1.0"
+  version = "1.0.0"
   
-    # convention          = local.convention
+    convention          = local.convention
     location            = local.location
     name                = local.name
     solution_plan_map   = local.solution_plan_map 
     prefix              = local.prefix
-    resource_group_name = module.rg_test.names.test
+    resource_group_name = azurerm_resource_group.rg_test.name
     tags                = local.tags
 }
 
 module "diags_test" {
   source  = "aztfmod/caf-diagnostics-logging/azurerm"
-  version = "0.1.2"
+  version = "1.0.0"
 
-  resource_group_name   = module.rg_test.names.test
+  resource_group_name   = azurerm_resource_group.rg_test.name
   prefix                = local.prefix
   location              = local.location
   tags                  = local.tags
+  convention            = local.convention
+  name                  = local.name
 }
 
 module "akv_test" {
   source = "../../"
   
-  prefix                   = local.prefix
   convention               = local.convention
   akv_config               = local.akv_config
-  rg                       = module.rg_test.names.test
+  resource_group_name      = azurerm_resource_group.rg_test.name
   location                 = local.location 
   tags                     = local.tags
   log_analytics_workspace  = module.la_test

--- a/examples/akv/akv.tf
+++ b/examples/akv/akv.tf
@@ -11,7 +11,7 @@ resource "azurerm_resource_group" "rg_test" {
 
 module "la_test" {
   source  = "aztfmod/caf-log-analytics/azurerm"
-  version = "2.0.0"
+  version = "2.0.1"
   
     convention          = local.convention
     location            = local.location
@@ -24,7 +24,7 @@ module "la_test" {
 
 module "diags_test" {
   source  = "aztfmod/caf-diagnostics-logging/azurerm"
-  version = "2.0.0"
+  version = "2.0.1"
 
   resource_group_name   = azurerm_resource_group.rg_test.name
   prefix                = local.prefix

--- a/examples/akv/locals.tf
+++ b/examples/akv/locals.tf
@@ -14,9 +14,9 @@ locals {
         owner           = "CAF"
     }
     solution_plan_map = {
-        NetworkMonitoring = {
+        KeyVaultAnalytics = {
             "publisher" = "Microsoft"
-            "product"   = "OMSGallery/NetworkMonitoring"
+            "product"   = "OMSGallery/KeyVaultAnalytics"
         },
     }
 

--- a/examples/akv/locals.tf
+++ b/examples/akv/locals.tf
@@ -1,11 +1,11 @@
 locals {
-    convention = "random"
+    convention = "cafrandom"
     name = "caftestakv"
     location = "southeastasia"
     prefix = ""
     resource_groups = {
         test = { 
-            name     = "test-caf-azfw"
+            name     = "test-caf-akv"
             location = "southeastasia" 
         },
     }

--- a/examples/akv/locals.tf
+++ b/examples/akv/locals.tf
@@ -21,7 +21,7 @@ locals {
     }
 
     akv_config = {
-        name       = "monakv"
+        name       = "test-caf-akv"
 
         akv_features = {
             enabled_for_disk_encryption = true

--- a/module.tf
+++ b/module.tf
@@ -1,16 +1,16 @@
-module "caf_name_kv" {
-  source  = "aztfmod/caf-naming/azurerm"
-  version = "~> 0.1.0"
-  
-  name    = var.akv_config.name
-  type    = "kv"
-  convention  = var.convention
+resource "azurecaf_naming_convention" "caf_name_kv" {  
+  name          = var.akv_config.name
+  prefix        = var.prefix != "" ? var.prefix : null
+  postfix       = var.postfix != "" ? var.postfix : null
+  max_length    = var.max_length != "" ? var.max_length : null
+  resource_type = "azurerm_key_vault"
+  convention    = var.convention
 }
 
 resource "azurerm_key_vault" "akv" {
-    name                            = module.caf_name_kv.kv
+    name                            = azurecaf_naming_convention.caf_name_kv.result
     location                        = var.location
-    resource_group_name             = var.rg
+    resource_group_name             = var.resource_group_name
     tenant_id                       = data.azurerm_client_config.current.tenant_id
     tags                            = local.tags
     sku_name                        = var.akv_config.sku_name

--- a/variables.tf
+++ b/variables.tf
@@ -8,17 +8,14 @@ variable "resource_group_name" {
 
 variable "tags" {
   description = "(Required) Tags to be applied to the AKV to be created"
-  
 }
 
 variable "diagnostics_map" {
   description = "(Required) Storage account and Event Hub for AKV"  
-
 }
 
 variable "log_analytics_workspace" {
   description = "(Required) Log Analytics workspace for AKV"
-  
 }
 
 variable "diagnostics_settings" {

--- a/variables.tf
+++ b/variables.tf
@@ -2,8 +2,8 @@ variable "location" {
   description = "(Required) Location of the AKV to be created"   
 }
 
-variable "rg" {
-  description = "(Required) Resource group of the AKV to be created"    
+variable "resource_group_name" {
+  description = "(Required) Resource group name of the AKV to be created"    
 }
 
 variable "tags" {
@@ -25,14 +25,28 @@ variable "diagnostics_settings" {
  description = "(Required) Map with the diagnostics settings for AKV"
 }
 
-variable "prefix" {
-  description = "(Optional) You can use a prefix to add to the list of resource groups you want to create"
-}
-
 variable "akv_config" {
   description = "(Required) Key Vault Configuration Object"
 }
 
 variable "convention" {
   description = "(Required) Naming convention method to use"  
+}
+
+variable "prefix" {
+  description = "(Optional) You can use a prefix to the name of the resource"
+  type        = string
+  default = ""
+}
+
+variable "postfix" {
+  description = "(Optional) You can use a postfix to the name of the resource"
+  type        = string
+  default = ""
+}
+
+variable "max_length" {
+  description = "(Optional) You can speficy a maximum length to the name of the resource"
+  type        = string
+  default = ""
 }


### PR DESCRIPTION
## v2.0 (March 2020)

FEATURES: 
* **new feature:**  Add support for azurerm 2.x and azurecaf providers ([#3](https://github.com/aztfmod/terraform-azurerm-caf-keyvault/issues/3))
